### PR TITLE
created composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "kwi/urllinker",
+    "description": "Autolink URLs in text or html",
+    "type": "library",
+    "license": "CC0-1.0",
+    "homepage": "http://www.kwi.dk/projects/php/UrlLinker/",
+    "authors": [
+        {
+            "name": "Søren Løvborg",
+            "role": "Developer"
+        },
+        {
+            "name": "Dawid Nowak",
+            "email": "code@dnowak.pl",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "source": "https://bitbucket.org/kwi/urllinker",
+        "issues": "https://bitbucket.org/kwi/urllinker/issues"
+    },
+    "require": {
+        "php": ">=5.3"
+    }
+}


### PR DESCRIPTION
In response to https://github.com/kwi-dk/UrlLinker/issues/1

For Composer to work, a repo is required to have a config file.

This is a simplified version of https://github.com/kwi-dk/UrlLinker/blob/bleeding/composer.json